### PR TITLE
Disable Spatial IO from Applied Energistics

### DIFF
--- a/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -132,7 +132,7 @@ features {
         B:PowerGen=true
         B:QuantumNetworkBridge=true
         B:Security=true
-        B:SpatialIO=true
+        B:SpatialIO=false
     }
 
     networkbuses {


### PR DESCRIPTION
It lets users create a sub-dimension to build a base in. This dimension is not accessible for other players making it "invincible" to attacks. Doesn't fit to Voltz.
