### PR TITLE
Updated DigitalMinerUsage

### DIFF
--- a/config/Mekanism.cfg
+++ b/config/Mekanism.cfg
@@ -388,7 +388,7 @@ usage {
     D:ChemicalWasherUsage=200.0
     D:CombinerUsage=50.0
     D:CrusherUsage=50.0
-    D:DigitalMinerUsage=100.0
+    D:DigitalMinerUsage=300.0
     D:ElectricPumpUsage=100.0
     D:EnergizedSmelterUsage=50.0
     D:EnrichmentChamberUsage=50.0


### PR DESCRIPTION
Right now it's set to 100J/t which means it can be run with 4 heat generators (if each is set up optimal they'll produce 25 J/t) -> This is about 3-4 stacks of ore with 2mj. The Digital Miner is endgame and mines specific ores at a decent rate. With the current change it would use 12 instead of 4 (if it runs without speed upgrades and silk touch which is still decently fast.) making it harder to reach endgame status / unlimited ore. The ultimate number needs tweaking. -> Can be easily adjusted during open testing and feedback.
